### PR TITLE
Performance fixes for insert and update

### DIFF
--- a/Source/DATAFilter.m
+++ b/Source/DATAFilter.m
@@ -39,6 +39,8 @@
     NSMutableArray *remoteObjectIDs = [[changes valueForKey:remoteKey] mutableCopy];
     [remoteObjectIDs removeObject:[NSNull null]];
 
+    NSDictionary *changeIDAndChange = [NSDictionary dictionaryWithObjects:changes forKeys:remoteObjectIDs];
+    
     NSMutableSet *intersection = [NSMutableSet setWithArray:remoteObjectIDs];
     [intersection intersectSet:[NSSet setWithArray:fetchedObjectIDs]];
     NSArray *updatedObjectIDs = [intersection allObjects];
@@ -60,27 +62,21 @@
     }
 
     for (id fetchedID in insertedObjectIDs) {
-        [changes enumerateObjectsUsingBlock:^(NSDictionary *objectDict, NSUInteger idx, BOOL *stop) {
-            if ([[objectDict objectForKey:remoteKey] isEqual:fetchedID]) {
-                if (inserted) {
-                    inserted(objectDict);
-                }
-            }
-        }];
+        NSDictionary *objectDict = changeIDAndChange[fetchedID];
+        if (inserted) {
+            inserted(objectDict);
+        }
     }
 
     for (id fetchedID in updatedObjectIDs) {
-        [changes enumerateObjectsUsingBlock:^(NSDictionary *objectDict, NSUInteger idx, BOOL *stop) {
-            if ([[objectDict objectForKey:remoteKey] isEqual:fetchedID]) {
-                NSManagedObjectID *objectID = [dictionaryIDAndObjectID objectForKey:fetchedID];
-                if (objectID) {
-                    NSManagedObject *object = [context objectWithID:objectID];
-                    if (object && updated) {
-                        updated(objectDict, object);
-                    }
-                }
+        NSDictionary *objectDict = changeIDAndChange[fetchedID];
+        NSManagedObjectID *objectID = [dictionaryIDAndObjectID objectForKey:fetchedID];
+        if (objectID) {
+            NSManagedObject *object = [context objectWithID:objectID];
+            if (object && updated) {
+                updated(objectDict, object);
             }
-        }];
+        }
     }
 }
 


### PR DESCRIPTION
Rather than stacking for loops, an O(N^2) operation, this pre-calculates a remote ID to remote object dictionary, in O(N) time, and then fetches from it each time(in constant time due to dictionary hashing), reducing the whole method to O(N) time which should be very useful in large import operations.

It costs a little bit of memory in return for a lot less CPU time. If this tradeoff isn't acceptable, at least setting stop when searching through the changes array would save a non-negligible amount of time, but still keeps the algorithm in the O(N^2) category.