### PR TITLE
Fix a bug where duplicate objects would be inserted

### DIFF
--- a/Source/DATAFilter.m
+++ b/Source/DATAFilter.m
@@ -42,6 +42,7 @@
 
     NSDictionary *remoteIDAndChange = [NSDictionary dictionaryWithObjects:changes
                                                                   forKeys:remoteObjectIDs];
+    remoteObjectIDs = [remoteIDAndChange allKeys];
 
     NSMutableSet *intersection = [NSMutableSet setWithArray:remoteObjectIDs];
     [intersection intersectSet:[NSSet setWithArray:fetchedObjectIDs]];


### PR DESCRIPTION
Due to the fact `changes` is an array which may contain duplicates (i.e. multiple objects with the same remoteKey-value), you must make sure to clean `remoteObjectIDs` from duplicates.
Otherwise it would propagate the duplicates into `insertedObjectIDs` (which is not a set but an array) which in turn would make the `for loop` over `insertedObjectIDs` insert duplicate objects.