### PR TITLE
Added a parameter `operations`

### DIFF
--- a/Source/DATAFilter.h
+++ b/Source/DATAFilter.h
@@ -1,5 +1,12 @@
 @import CoreData;
 
+typedef NS_OPTIONS(NSUInteger, DATAFilterChangOperations) {
+    DATAFilterChangOperationInsert = 1 << 0,
+    DATAFilterChangOperationUpdate = 1 << 1,
+    DATAFilterChangOperationDelete = 1 << 2,
+    DATAFilterChangOperationAll = 0xFFFFFFFF
+};
+
 @interface DATAFilter : NSObject
 
 + (void)changes:(NSArray *)changes
@@ -11,6 +18,26 @@
         updated:(void (^)(NSDictionary *objectJSON, NSManagedObject *updatedObject))updated;
 
 + (void)changes:(NSArray *)changes
+  inEntityNamed:(NSString *)entityName
+       localKey:(NSString *)localKey
+      remoteKey:(NSString *)remoteKey
+        context:(NSManagedObjectContext *)context
+      predicate:(NSPredicate *)predicate
+       inserted:(void (^)(NSDictionary *objectJSON))inserted
+        updated:(void (^)(NSDictionary *objectJSON, NSManagedObject *updatedObject))updated;
+
+
++ (void)changes:(NSArray *)changes
+     operations:(DATAFilterChangOperations)operations
+  inEntityNamed:(NSString *)entityName
+       localKey:(NSString *)localKey
+      remoteKey:(NSString *)remoteKey
+        context:(NSManagedObjectContext *)context
+       inserted:(void (^)(NSDictionary *objectJSON))inserted
+        updated:(void (^)(NSDictionary *objectJSON, NSManagedObject *updatedObject))updated;
+
++ (void)changes:(NSArray *)changes
+     operations:(DATAFilterChangOperations)operations
   inEntityNamed:(NSString *)entityName
        localKey:(NSString *)localKey
       remoteKey:(NSString *)remoteKey


### PR DESCRIPTION
The `operations` parameter is used to control the insert/update/delete operations. User can easily turn on/off a specific operation. For example, there is an API in server side, which return only part of the data, to ensure other data will not be deleted, we don't want to delete, insert + update is enough.